### PR TITLE
fix: nest functions to properly check for padding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "encryption-envelope-js",
-  "version": "1.1.6",
+  "version": "1.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "encryption-envelope-js",
-      "version": "1.1.6",
+      "version": "1.2.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/libsodium-wrappers": "^0.7.5",

--- a/src/index.ts
+++ b/src/index.ts
@@ -197,7 +197,7 @@ export class DIDComm {
     }
 
     private strB64dec(input: any) {
-        return this.sodium.to_string(this.sodium.from_base64(input, this.sodium.base64_variants.URLSAFE))
+      return this.sodium.to_string(this.b64dec(input))
     }
 
     private encryptPlaintext(message: any, addData: any, key: any) {


### PR DESCRIPTION
I didn't include the test we wrote to check the `b64dec`, since it seemed unnecessary after the fix, but I still have the change locally, so if you want that pushed up, let me know. 

Signed-off-by: Micah Peltier <micah6_8@yahoo.com>